### PR TITLE
ISE\lib\nt64\libPortability.dll was missing

### DIFF
--- a/patch.bat
+++ b/patch.bat
@@ -1,14 +1,15 @@
-copy 14.7\ISE_DS\.xinstall\bin\nt\libPortability.dll 14.7\ISE_DS\.xinstall\bin\nt\libPortability.dll.bak
-copy 14.7\ISE_DS\common\lib\nt\libPortability.dll 14.7\ISE_DS\common\lib\nt\libPortability.dll.bak
-copy 14.7\ISE_DS\EDK\lib\nt\libPortability.dll 14.7\ISE_DS\EDK\lib\nt\libPortability.dll.bak
-copy 14.7\ISE_DS\ISE\lib\nt\libPortability.dll 14.7\ISE_DS\ISE\lib\nt\libPortability.dll.bak
-copy 14.7\ISE_DS\ISE\sysgen\bin\nt\libPortability.dll 14.7\ISE_DS\ISE\sysgen\bin\nt\libPortability.dll.bak
+ren 14.7\ISE_DS\.xinstall\bin\nt\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\common\lib\nt\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\EDK\lib\nt\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\ISE\lib\nt\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\ISE\sysgen\bin\nt\libPortability.dll libPortability.dll.bak
 
-copy 14.7\ISE_DS\.xinstall\bin\nt64\libPortability.dll 14.7\ISE_DS\.xinstall\bin\nt64\libPortability.dll.bak
-copy 14.7\ISE_DS\common\lib\nt64\libPortability.dll 14.7\ISE_DS\common\lib\nt64\libPortability.dll.bak
-copy 14.7\ISE_DS\EDK\lib\nt64\libPortability.dll 14.7\ISE_DS\EDK\lib\nt64\libPortability.dll.bak
-copy 14.7\ISE_DS\EDK\lib\nt64\sdk\libPortability.dll 14.7\ISE_DS\EDK\lib\nt64\sdk\libPortability.dll.bak
-copy 14.7\ISE_DS\ISE\sysgen\bin\nt64\libPortability.dll 14.7\ISE_DS\ISE\sysgen\bin\nt64\libPortability.dll.bak
+ren 14.7\ISE_DS\.xinstall\bin\nt64\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\common\lib\nt64\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\EDK\lib\nt64\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\EDK\lib\nt64\sdk\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\ISE\lib\nt64\libPortability.dll libPortability.dll.bak
+ren 14.7\ISE_DS\ISE\sysgen\bin\nt64\libPortability.dll libPortability.dll.bak
 
 copy 14.7\ISE_DS\ISE\lib\nt\libPortabilityNOSH.dll 14.7\ISE_DS\.xinstall\bin\nt\libPortability.dll
 copy 14.7\ISE_DS\ISE\lib\nt\libPortabilityNOSH.dll 14.7\ISE_DS\common\lib\nt\libPortability.dll
@@ -20,8 +21,5 @@ copy 14.7\ISE_DS\ISE\lib\nt64\libPortabilityNOSH.dll 14.7\ISE_DS\.xinstall\bin\n
 copy 14.7\ISE_DS\ISE\lib\nt64\libPortabilityNOSH.dll 14.7\ISE_DS\common\lib\nt64\libPortability.dll
 copy 14.7\ISE_DS\ISE\lib\nt64\libPortabilityNOSH.dll 14.7\ISE_DS\EDK\lib\nt64\libPortability.dll
 copy 14.7\ISE_DS\ISE\lib\nt64\libPortabilityNOSH.dll 14.7\ISE_DS\EDK\lib\nt64\sdk\libPortability.dll
+copy 14.7\ISE_DS\ISE\lib\nt64\libPortabilityNOSH.dll 14.7\ISE_DS\ISE\lib\nt64\libPortability.dll
 copy 14.7\ISE_DS\ISE\lib\nt64\libPortabilityNOSH.dll 14.7\ISE_DS\ISE\sysgen\bin\nt64\libPortability.dll
-
-
-
-

--- a/revert.bat
+++ b/revert.bat
@@ -8,4 +8,5 @@ copy 14.7\ISE_DS\.xinstall\bin\nt64\libPortability.dll.bak 14.7\ISE_DS\.xinstall
 copy 14.7\ISE_DS\common\lib\nt64\libPortability.dll.bak 14.7\ISE_DS\common\lib\nt64\libPortability.dll
 copy 14.7\ISE_DS\EDK\lib\nt64\libPortability.dll.bak 14.7\ISE_DS\EDK\lib\nt64\libPortability.dll
 copy 14.7\ISE_DS\EDK\lib\nt64\sdk\libPortability.dll.bak 14.7\ISE_DS\EDK\lib\nt64\sdk\libPortability.dll
+copy 14.7\ISE_DS\ISE\lib\nt64\libPortability.dll.bak 14.7\ISE_DS\ISE\lib\nt64\libPortability.dll
 copy 14.7\ISE_DS\ISE\sysgen\bin\nt64\libPortability.dll.bak 14.7\ISE_DS\ISE\sysgen\bin\nt64\libPortability.dll


### PR DESCRIPTION
Project Navigator 64 still crashed, as \ISE\lib\nt64\libPortability.dll was not fixed.